### PR TITLE
gradle: fix apk output filename

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,7 +74,7 @@ android {
                     .forEach { output ->
                         val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss").format(Date())
                         val outputFileName =
-                            "tmoney-${variant.name}-${variant.versionName}-$timestamp.apk"
+                            "catnews-${variant.name}-${variant.versionName}-$timestamp.apk"
                         output.outputFileName = outputFileName
                     }
             }


### PR DESCRIPTION
Mistakenly used other app name when copying the gradle build script to this project. The correct apk prefix for this app should be `catnews`.