### PR TITLE
[chore] (#189) GitHub action to submit release builds

### DIFF
--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           name: app-build-artifacts
           path: |
-            app/build/outputs/apk/release/*.apk
-            app/build/outputs/bundle/release/*.aab
+            cat-news/app/build/outputs/apk/release/*.apk
+            cat-news/app/build/outputs/bundle/release/*.aab
 
       - name: Create Release
         id: create_release
@@ -62,7 +62,7 @@ jobs:
 
       - name: Find APK file
         run: |
-          apk_path=$(find ./app/build/outputs/apk/release -name "catnews-*.apk" | head -n 1)
+          apk_path=$(find ./cat-news/app/build/outputs/apk/release -name "catnews-*.apk" | head -n 1)
           echo "apk_path=$apk_path" >> $GITHUB_ENV
 
       - name: Upload Release Asset APK
@@ -77,7 +77,7 @@ jobs:
 
       - name: Find AAB file
         run: |
-          aab_path=$(find ./app/build/outputs/bundle/release -name "catnews-*.aab" | head -n 1)
+          aab_path=$(find ./cat-news/app/build/outputs/bundle/release -name "catnews-*.aab" | head -n 1)
           echo "aab_path=$aab_path" >> $GITHUB_ENV
 
       - name: Upload Release Asset AAB

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -44,15 +44,14 @@ jobs:
         with:
           name: app-build-artifacts
           path: |
-            cat-news/app/build/outputs/apk/release/*.apk
-            cat-news/app/build/outputs/bundle/release/*.aab
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/bundle/release/*.aab
 
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
         with:
+          token: ${{ secrets.PAT_FOR_RELEASES }}
           tag_name: ${{ github.ref_name }}
           release_name: Release ${{ env.version }}
           draft: false

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -44,14 +44,15 @@ jobs:
         with:
           name: app-build-artifacts
           path: |
-            app/build/outputs/apk/release/*.apk
-            app/build/outputs/bundle/release/*.aab
+            app/build/outputs/apk/prod/release/*.apk
+            app/build/outputs/bundle/prodRelease/*.aab
 
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
         with:
-          token: ${{ secrets.PAT_FOR_RELEASES }}
           tag_name: ${{ github.ref_name }}
           release_name: Release ${{ env.version }}
           draft: false
@@ -61,7 +62,7 @@ jobs:
 
       - name: Find APK file
         run: |
-          apk_path=$(find ./cat-news/app/build/outputs/apk/release -name "catnews-*.apk" | head -n 1)
+          apk_path=$(find ./cat-news/app/build/outputs/apk/prod/release -name "catnews-*.apk" | head -n 1)
           echo "apk_path=$apk_path" >> $GITHUB_ENV
 
       - name: Upload Release Asset APK
@@ -76,7 +77,7 @@ jobs:
 
       - name: Find AAB file
         run: |
-          aab_path=$(find ./cat-news/app/build/outputs/bundle/release -name "catnews-*.aab" | head -n 1)
+          aab_path=$(find ./cat-news/app/build/outputs/bundle/prodRelease -name "catnews-*.aab" | head -n 1)
           echo "aab_path=$aab_path" >> $GITHUB_ENV
 
       - name: Upload Release Asset AAB

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Find APK file
         run: |
-          apk_path=$(find ./cat-news/app/build/outputs/apk/prod/release -name "catnews-*.apk" | head -n 1)
+          apk_path=$(find ./app/build/outputs/apk/prod/release -name "catnews-*.apk" | head -n 1)
           echo "apk_path=$apk_path" >> $GITHUB_ENV
 
       - name: Upload Release Asset APK
@@ -77,7 +77,7 @@ jobs:
 
       - name: Find AAB file
         run: |
-          aab_path=$(find ./cat-news/app/build/outputs/bundle/prodRelease -name "catnews-*.aab" | head -n 1)
+          aab_path=$(find ./app/build/outputs/bundle/prodRelease -name "catnews-*.aab" | head -n 1)
           echo "aab_path=$aab_path" >> $GITHUB_ENV
 
       - name: Upload Release Asset AAB

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -1,0 +1,91 @@
+name: Android Build and Release on Tag
+
+on:
+  create:
+
+jobs:
+  build-and-release:
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decode Keystore
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'release.jks'
+          encodedString: ${{ secrets.KEYSTORE }}
+
+      - uses: actions/checkout@v4
+
+      - name: set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Gradle build
+        run: ./gradlew clean bundleRelease assembleRelease --no-daemon
+        env:
+          BITRISE: 'true'
+          KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
+          BITRISEIO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_ALIAS }}
+          BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
+          BITRISEIO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PASSWORD }}
+
+      - name: Extract Version Number
+        run: echo "version=${GITHUB_REF#refs/tags/release/}" >> $GITHUB_ENV
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-build-artifacts
+          path: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/bundle/release/*.aab
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ env.version }}
+          draft: false
+          prerelease: false
+          body: "Release notes for Cat News version ${{ env.version }} will be posted soon."
+          commitish: ${{ github.sha }}
+
+      - name: Find APK file
+        run: |
+          apk_path=$(find ./app/build/outputs/apk/release -name "catnews-*.apk" | head -n 1)
+          echo "apk_path=$apk_path" >> $GITHUB_ENV
+
+      - name: Upload Release Asset APK
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.apk_path }}
+          asset_name: catnews-prodRelease-${{ env.version }}.apk
+          asset_content_type: application/vnd.android.package-archive
+
+      - name: Find AAB file
+        run: |
+          aab_path=$(find ./app/build/outputs/bundle/release -name "catnews-*.aab" | head -n 1)
+          echo "aab_path=$aab_path" >> $GITHUB_ENV
+
+      - name: Upload Release Asset AAB
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.aab_path }}
+          asset_name: catnews-prodRelease-${{ env.version }}.aab
+          asset_content_type: application/vnd.android.package-archive

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,7 +74,7 @@ android {
                     .forEach { output ->
                         val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss").format(Date())
                         val outputFileName =
-                            "catnews-${variant.name}-${variant.versionName}-$timestamp.apk"
+                            "catnews-${variant.versionName}-$timestamp-${variant.name}.apk"
                         output.outputFileName = outputFileName
                     }
             }


### PR DESCRIPTION
This Github Action yaml automatically build apk and aab, then create a new Github Release entry using the version number specified in the tag `release/v1.2.3` 

So that we do not have to include these binaries in the commits.