### PR TITLE
[chore] make keystore optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ The project now requires no initial keystore setup to run the debug build.
 
 ## Binaries download
 
-If you want to try out the app without building it, check out the [`Releases section`](https://github.com/ryanw-mobile/cat-news/releases) where you can find the APK and App Bundles for each major version. They were built to connect to real API endpoints, thus you need a data connection to run the app.
+If you want to try out the app without building it, check out
+the [Releases section](https://github.com/ryanw-mobile/cat-news/releases) where you can find the APK
+and App Bundles for each major version. They were built to connect to real API endpoints, thus you
+need a data connection to run the app.
 
 ## Requirements
 
@@ -89,9 +92,9 @@ If you want to try out the app without building it, check out the [`Releases sec
 
 ## Setting up the Keystore
 
-Debug builds now are not signed.
-This means you do not have to set up a keystore to run the debug builds, and Gradle will show no
-errors during the initial sync when the `keystore.properties` does not exist.
+Keystore is completely optional. Debug builds now are not signed.
+Release builds will be signed if either the keystore file or environment variables are set.
+Otherwise, the app will be built unsigned.
 
 ### Local
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,13 +23,13 @@ android {
             val isRunningOnCI = System.getenv("BITRISE") == "true"
             val keystorePropertiesFile = file("../../keystore.properties")
 
-            if (isRunningOnCI || !keystorePropertiesFile.exists()) {
+            if (isRunningOnCI) {
                 println("Signing Config: using environment variables")
                 keyAlias = System.getenv("BITRISEIO_ANDROID_KEYSTORE_ALIAS")
                 keyPassword = System.getenv("BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD")
                 storeFile = file(System.getenv("KEYSTORE_LOCATION"))
                 storePassword = System.getenv("BITRISEIO_ANDROID_KEYSTORE_PASSWORD")
-            } else {
+            } else if (keystorePropertiesFile.exists()) {
                 println("Signing Config: using keystore properties")
                 val properties = Properties()
                 InputStreamReader(
@@ -43,6 +43,8 @@ android {
                 keyPassword = properties.getProperty("pass")
                 storeFile = file(properties.getProperty("store"))
                 storePassword = properties.getProperty("storePass")
+            } else {
+                println("Signing Config: skipping signing")
             }
         }
     }
@@ -97,7 +99,11 @@ android {
                     "proguard-rules.pro",
                 ),
             )
-            signingConfig = signingConfigs.getByName("release")
+
+            signingConfigs.getByName("release").keyAlias?.let {
+                signingConfig = signingConfigs.getByName("release")
+            }
+
             setOutputFileName()
         }
     }


### PR DESCRIPTION
Add additional checking, so that when both local file and environmental variables don't hold a valid keystore, we build the release unsigned without throwing any errors. That's great for visitors to get the code running quickly.